### PR TITLE
Merge in MFA policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ No Modules.
 |------|-------------|------|---------|:--------:|
 | allow\_access\_keys | Allow users to manage their own access keys. | `bool` | `true` | no |
 | allow\_account\_aliases | Allow users to list the account aliases. | `bool` | `true` | no |
-| allow\_account\_summary | Allow users to get the account summary. | `bool` | `true` | no |
 | allow\_git\_credentials | Allow users to manage their own git credentials. | `bool` | `true` | no |
 | allow\_mfa\_device | Allow users to manage their own MFA device. | `bool` | `true` | no |
 | allow\_signing\_certificates | Allow users to manage their own signing certificates. | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Usage
 
-Configures IAM policy to allow users to manage their own credentials.
+Configures IAM policy to allow users to manage their own credentials and optionally enforces MFA.
 
-Policy pulled from [AWS: Allows IAM users to manage their own credentials on the My Security Credentials page](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-no-mfa.html)
+Policy pulled from [AWS: Allows IAM users to manage their own credentials on the My Security Credentials page](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-no-mfa.html) but heavily modified.
 
 Creates the following resources:
 
-* IAM policy allowing users to manage their own security credentials.
+* IAM policy allowing users to manage their own security credentials and optionally enforces MFA.
 * IAM group policy attachment for defining which IAM groups can manage their own credentials.
 * IAM user policy attachment for defining which IAM users can manage their own credentials.
 
@@ -64,11 +64,18 @@ No Modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | allow\_access\_keys | Allow users to manage their own access keys. | `bool` | `true` | no |
+| allow\_account\_aliases | Allow users to list the account aliases. | `bool` | `true` | no |
+| allow\_account\_summary | Allow users to get the account summary. | `bool` | `true` | no |
 | allow\_git\_credentials | Allow users to manage their own git credentials. | `bool` | `true` | no |
+| allow\_mfa\_device | Allow users to manage their own MFA device. | `bool` | `true` | no |
 | allow\_signing\_certificates | Allow users to manage their own signing certificates. | `bool` | `true` | no |
 | allow\_ssh\_keys | Allow users to manage their own SSH keys. | `bool` | `true` | no |
-| iam\_groups | List of IAM groups to allow access to managing their own crednetials. | `list(string)` | `[]` | no |
-| iam\_users | List of IAM users to allow access to managing their own crednetials. | `list(string)` | `[]` | no |
+| description | The description of the AWS IAM policy. | `string` | `"Allows an IAM user to manage their own credentials"` | no |
+| enforce\_mfa | Requires users to login with MFA for most AWS actions. | `bool` | `false` | no |
+| iam\_groups | List of IAM groups to allow access to managing their own credentials. | `list(string)` | `[]` | no |
+| iam\_users | List of IAM users to allow access to managing their own credentials. | `list(string)` | `[]` | no |
+| name | Name of the AWS IAM policy. | `string` | `"self-manage-credentials"` | no |
+| require\_mfa | Requires users to login with MFA when managing their own credentials. | `bool` | `true` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,13 @@
 /**
  * ## Usage
  *
- * Configures IAM policy to allow users to manage their own credentials.
+ * Configures IAM policy to allow users to manage their own credentials and optionally enforces MFA.
  *
- * Policy pulled from [AWS: Allows IAM users to manage their own credentials on the My Security Credentials page](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-no-mfa.html)
+ * Policy pulled from [AWS: Allows IAM users to manage their own credentials on the My Security Credentials page](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-no-mfa.html) but heavily modified.
  *
  * Creates the following resources:
  *
- * * IAM policy allowing users to manage their own security credentials.
+ * * IAM policy allowing users to manage their own security credentials and optionally enforces MFA.
  * * IAM group policy attachment for defining which IAM groups can manage their own credentials.
  * * IAM user policy attachment for defining which IAM users can manage their own credentials.
  *
@@ -36,12 +36,41 @@
 data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "main" {
+  dynamic "statement" {
+    for_each = var.allow_account_aliases ? [var.allow_account_aliases] : []
+    content {
+      sid    = "AllowListAccountAliases"
+      effect = "Allow"
+      actions = [
+        "iam:ListAccountAliases",
+      ]
+      resources = ["*"]
+    }
+  }
+  dynamic "statement" {
+    for_each = var.allow_account_summary ? [var.allow_account_summary] : []
+    content {
+      sid    = "AllowGetAccountSummary"
+      effect = "Allow"
+      actions = [
+        "iam:GetAccountSummary",
+      ]
+      resources = ["*"]
+      dynamic "condition" {
+        for_each = var.require_mfa ? [true] : []
+        content {
+          test     = "Bool"
+          variable = "aws:MultiFactorAuthPresent"
+          values   = ["true"]
+        }
+      }
+    }
+  }
   statement {
-    sid    = "AllowViewAccountInfo"
+    sid    = "AllowGetAccountPasswordPolicy"
     effect = "Allow"
     actions = [
       "iam:GetAccountPasswordPolicy",
-      "iam:GetAccountSummary",
     ]
     resources = ["*"]
   }
@@ -53,6 +82,14 @@ data "aws_iam_policy_document" "main" {
       "iam:GetUser",
     ]
     resources = ["arn:${data.aws_partition.current.partition}:iam::*:user/$${aws:username}"]
+    dynamic "condition" {
+      for_each = var.require_mfa ? [true] : []
+      content {
+        test     = "Bool"
+        variable = "aws:MultiFactorAuthPresent"
+        values   = ["true"]
+      }
+    }
   }
   dynamic "statement" {
     for_each = var.allow_access_keys ? [var.allow_access_keys] : []
@@ -68,6 +105,14 @@ data "aws_iam_policy_document" "main" {
       resources = [
         format("arn:%s:iam::*:user/$${aws:username}", data.aws_partition.current.partition)
       ]
+      dynamic "condition" {
+        for_each = var.require_mfa ? [true] : []
+        content {
+          test     = "Bool"
+          variable = "aws:MultiFactorAuthPresent"
+          values   = ["true"]
+        }
+      }
     }
   }
   dynamic "statement" {
@@ -84,6 +129,14 @@ data "aws_iam_policy_document" "main" {
       resources = [
         format("arn:%s:iam::*:user/$${aws:username}", data.aws_partition.current.partition)
       ]
+      dynamic "condition" {
+        for_each = var.require_mfa ? [true] : []
+        content {
+          test     = "Bool"
+          variable = "aws:MultiFactorAuthPresent"
+          values   = ["true"]
+        }
+      }
     }
   }
   dynamic "statement" {
@@ -101,6 +154,14 @@ data "aws_iam_policy_document" "main" {
       resources = [
         format("arn:%s:iam::*:user/$${aws:username}", data.aws_partition.current.partition)
       ]
+      dynamic "condition" {
+        for_each = var.require_mfa ? [true] : []
+        content {
+          test     = "Bool"
+          variable = "aws:MultiFactorAuthPresent"
+          values   = ["true"]
+        }
+      }
     }
   }
   dynamic "statement" {
@@ -118,14 +179,106 @@ data "aws_iam_policy_document" "main" {
       resources = [
         format("arn:%s:iam::*:user/$${aws:username}", data.aws_partition.current.partition)
       ]
+      dynamic "condition" {
+        for_each = var.require_mfa ? [true] : []
+        content {
+          test     = "Bool"
+          variable = "aws:MultiFactorAuthPresent"
+          values   = ["true"]
+        }
+      }
+    }
+  }
+  dynamic "statement" {
+    for_each = var.allow_mfa_device ? [var.allow_mfa_device] : []
+    content {
+      sid    = "AllowListVirtualMFADevices"
+      effect = "Allow"
+      actions = [
+        "iam:ListVirtualMFADevices"
+      ]
+      resources = ["arn:${data.aws_partition.current.partition}:iam::*:mfa/*"]
+    }
+  }
+  dynamic "statement" {
+    for_each = var.allow_mfa_device ? [var.allow_mfa_device] : []
+    content {
+      sid    = "AllowManageMFADevice"
+      effect = "Allow"
+      actions = [
+        "iam:ListMFADevices",
+        "iam:EnableMFADevice",
+        "iam:ResyncMFADevice"
+      ]
+      resources = ["arn:${data.aws_partition.current.partition}:iam::*:user/$${aws:username}"]
+    }
+  }
+  dynamic "statement" {
+    for_each = var.allow_mfa_device ? [var.allow_mfa_device] : []
+    content {
+      sid    = "AllowDeactivateMFADevice"
+      effect = "Allow"
+      actions = [
+        "iam:DeactivateMFADevice"
+      ]
+      resources = ["arn:${data.aws_partition.current.partition}:iam::*:user/$${aws:username}"]
+      # This action requires MFA to be used.  If MFA was not required,
+      # an attacker with a compromised password could disable MFA and change it.
+      condition {
+        test     = "Bool"
+        variable = "aws:MultiFactorAuthPresent"
+        values   = ["true"]
+      }
+    }
+  }
+  dynamic "statement" {
+    for_each = var.allow_mfa_device ? [var.allow_mfa_device] : []
+    content {
+      sid    = "AllowManageVirtualMFADevice"
+      effect = "Allow"
+      actions = [
+        # If an MFA device does not exist yet, then your session won't have MFA set.
+        "iam:CreateVirtualMFADevice",
+        # You must deactivate a user's MFA device before you can delete it,
+        # therefore, this statement does not need a MultiFactorAuthPresent condition.
+        "iam:DeleteVirtualMFADevice"
+      ]
+      resources = ["arn:${data.aws_partition.current.partition}:iam::*:mfa/$${aws:username}"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enforce_mfa ? [var.enforce_mfa] : []
+    content {
+      sid    = "BlockMostAccessUnlessSignedInWithMFA"
+      effect = "Deny"
+      not_actions = [
+        # IAM Actions
+        "iam:ListAccountAliases",
+        # MFA Actions
+        "iam:CreateVirtualMFADevice",
+        "iam:DeleteVirtualMFADevice",
+        "iam:ListVirtualMFADevices",
+        "iam:EnableMFADevice",
+        "iam:ResyncMFADevice",
+        "iam:ListMFADevices",
+        # STS Actions
+        "sts:GetSessionToken",
+      ]
+      resources = ["*"]
+      condition {
+        test     = "BoolIfExists"
+        variable = "aws:MultiFactorAuthPresent"
+        values   = ["false"]
+      }
     }
   }
 }
 
 resource "aws_iam_policy" "main" {
-  name        = "self-manage-credentials"
+  name        = var.name
   path        = "/"
-  description = "Allows an IAM user to manage their own credentials"
+  description = var.description
   policy      = data.aws_iam_policy_document.main.json
 }
 

--- a/main.tf
+++ b/main.tf
@@ -47,25 +47,6 @@ data "aws_iam_policy_document" "main" {
       resources = ["*"]
     }
   }
-  dynamic "statement" {
-    for_each = var.allow_account_summary ? [var.allow_account_summary] : []
-    content {
-      sid    = "AllowGetAccountSummary"
-      effect = "Allow"
-      actions = [
-        "iam:GetAccountSummary",
-      ]
-      resources = ["*"]
-      dynamic "condition" {
-        for_each = var.require_mfa ? [true] : []
-        content {
-          test     = "Bool"
-          variable = "aws:MultiFactorAuthPresent"
-          values   = ["true"]
-        }
-      }
-    }
-  }
   statement {
     sid    = "AllowGetAccountPasswordPolicy"
     effect = "Allow"

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,37 @@
+variable "description" {
+  type        = string
+  description = "The description of the AWS IAM policy."
+  default     = "Allows an IAM user to manage their own credentials"
+}
+
 variable "iam_groups" {
-  description = "List of IAM groups to allow access to managing their own crednetials."
+  description = "List of IAM groups to allow access to managing their own credentials."
   type        = list(string)
   default     = []
 }
 
 variable "iam_users" {
-  description = "List of IAM users to allow access to managing their own crednetials."
+  description = "List of IAM users to allow access to managing their own credentials."
   type        = list(string)
   default     = []
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the AWS IAM policy."
+  default     = "self-manage-credentials"
+}
+
+variable "allow_account_aliases" {
+  type        = bool
+  description = "Allow users to list the account aliases."
+  default     = true
+}
+
+variable "allow_account_summary" {
+  type        = bool
+  description = "Allow users to get the account summary."
+  default     = true
 }
 
 variable "allow_access_keys" {
@@ -22,6 +46,12 @@ variable "allow_git_credentials" {
   default     = true
 }
 
+variable "allow_mfa_device" {
+  type        = bool
+  description = "Allow users to manage their own MFA device."
+  default     = true
+}
+
 variable "allow_signing_certificates" {
   type        = bool
   description = "Allow users to manage their own signing certificates."
@@ -32,4 +62,16 @@ variable "allow_ssh_keys" {
   type        = bool
   description = "Allow users to manage their own SSH keys."
   default     = true
+}
+
+variable "require_mfa" {
+  type        = bool
+  description = "Requires users to login with MFA when managing their own credentials."
+  default     = true
+}
+
+variable "enforce_mfa" {
+  type        = bool
+  description = "Requires users to login with MFA for most AWS actions."
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,36 +1,6 @@
-variable "description" {
-  type        = string
-  description = "The description of the AWS IAM policy."
-  default     = "Allows an IAM user to manage their own credentials"
-}
-
-variable "iam_groups" {
-  description = "List of IAM groups to allow access to managing their own credentials."
-  type        = list(string)
-  default     = []
-}
-
-variable "iam_users" {
-  description = "List of IAM users to allow access to managing their own credentials."
-  type        = list(string)
-  default     = []
-}
-
-variable "name" {
-  type        = string
-  description = "Name of the AWS IAM policy."
-  default     = "self-manage-credentials"
-}
-
 variable "allow_account_aliases" {
   type        = bool
   description = "Allow users to list the account aliases."
-  default     = true
-}
-
-variable "allow_account_summary" {
-  type        = bool
-  description = "Allow users to get the account summary."
   default     = true
 }
 
@@ -64,14 +34,38 @@ variable "allow_ssh_keys" {
   default     = true
 }
 
-variable "require_mfa" {
-  type        = bool
-  description = "Requires users to login with MFA when managing their own credentials."
-  default     = true
+variable "description" {
+  type        = string
+  description = "The description of the AWS IAM policy."
+  default     = "Allows an IAM user to manage their own credentials"
 }
 
 variable "enforce_mfa" {
   type        = bool
   description = "Requires users to login with MFA for most AWS actions."
   default     = false
+}
+
+variable "iam_groups" {
+  description = "List of IAM groups to allow access to managing their own credentials."
+  type        = list(string)
+  default     = []
+}
+
+variable "iam_users" {
+  description = "List of IAM users to allow access to managing their own credentials."
+  type        = list(string)
+  default     = []
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the AWS IAM policy."
+  default     = "self-manage-credentials"
+}
+
+variable "require_mfa" {
+  type        = bool
+  description = "Requires users to login with MFA when managing their own credentials."
+  default     = true
 }


### PR DESCRIPTION
Pending Questions:
- Can `iam:GetAccountSummary` be removed?  Would non-admin users ever need this permission?
- This policy currently requires MFA to be set before changing password.  More secure, since prevents someone from access keys from changing the users's password; however, could complicate some user onboarding experience.